### PR TITLE
Update README to use correct schematic rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Initiate the electromagnet.
 #### [Mini-Protoboard](http://amzn.to/1Hl3VQV)
 For soldering everything together.
 
-[![MagSpoof Schematic (DIP version)](http://samy.pl/magspoof/magdip-schematic.png)](http://samy.pl/magspoof/magdip-schematic.png)
+[![MagSpoof Schematic (DIP version)](https://raw.githubusercontent.com/samyk/magspoof/master/magspoof-schematic-dip.png)](https://raw.githubusercontent.com/samyk/magspoof/master/magspoof-schematic-dip.png)
 
 -----
 


### PR DESCRIPTION
The image was updated in commit: https://github.com/samyk/magspoof/commit/f7f1d3c868b5509da58ddc3946a1869d8c942584

but not updated in the README so it was difficult to find.
